### PR TITLE
Allow to create custom Request & Response

### DIFF
--- a/client.go
+++ b/client.go
@@ -66,8 +66,8 @@ func SetReceiveTimeout(timeout time.Duration) {
 	receiveTimeout = timeout
 }
 
-// getMessageID generates a string that the client has not yet used.
-func getMessageID() string {
+// GetMessageID generates a string that the client has not yet used.
+func GetMessageID() string {
 	lock.Lock()
 	messageID++
 	id := strconv.Itoa(messageID)

--- a/client_requests.go
+++ b/client_requests.go
@@ -14,8 +14,8 @@ var (
 	ErrReceiveTimeout = errors.New("receive timed out")
 )
 
-// sendRequest sends a request to the WebSocket server.
-func (c *Client) sendRequest(req Request) (chan map[string]interface{}, error) {
+// SendRequest sends a request to the WebSocket server.
+func (c *Client) SendRequest(req Request) (chan map[string]interface{}, error) {
 	if !c.connected {
 		return nil, ErrNotConnected
 	}

--- a/codegen/protocol.py
+++ b/codegen/protocol.py
@@ -137,7 +137,7 @@ def gen_request(data: Dict) -> str:
         if r.sent {{
             return ErrAlreadySent
         }}
-        future, err := c.sendRequest(r)
+        future, err := c.SendRequest(r)
         if err != nil {{
             return err
         }}
@@ -226,7 +226,7 @@ def gen_request_new(request: Dict):
     variables = go_variables(request.get("params", []), export=False)
     default_args = f"""
         _request{{
-            ID_: getMessageID(),
+            ID_: GetMessageID(),
             Type_: "{request["name"]}",
             err: make(chan error, 1),
         }},

--- a/requests_general.go
+++ b/requests_general.go
@@ -22,7 +22,7 @@ type GetVersionRequest struct {
 func NewGetVersionRequest() GetVersionRequest {
 	return GetVersionRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetVersion",
 			err:   make(chan error, 1),
 		},
@@ -35,7 +35,7 @@ func (r *GetVersionRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ type GetAuthRequiredRequest struct {
 func NewGetAuthRequiredRequest() GetAuthRequiredRequest {
 	return GetAuthRequiredRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetAuthRequired",
 			err:   make(chan error, 1),
 		},
@@ -137,7 +137,7 @@ func (r *GetAuthRequiredRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func NewAuthenticateRequest(auth string) AuthenticateRequest {
 	return AuthenticateRequest{
 		auth,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "Authenticate",
 			err:   make(chan error, 1),
 		},
@@ -235,7 +235,7 @@ func (r *AuthenticateRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ func NewSetHeartbeatRequest(enable bool) SetHeartbeatRequest {
 	return SetHeartbeatRequest{
 		enable,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetHeartbeat",
 			err:   make(chan error, 1),
 		},
@@ -326,7 +326,7 @@ func (r *SetHeartbeatRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -404,7 +404,7 @@ func NewSetFilenameFormattingRequest(filenameFormatting string) SetFilenameForma
 	return SetFilenameFormattingRequest{
 		filenameFormatting,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetFilenameFormatting",
 			err:   make(chan error, 1),
 		},
@@ -417,7 +417,7 @@ func (r *SetFilenameFormattingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -491,7 +491,7 @@ type GetFilenameFormattingRequest struct {
 func NewGetFilenameFormattingRequest() GetFilenameFormattingRequest {
 	return GetFilenameFormattingRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetFilenameFormatting",
 			err:   make(chan error, 1),
 		},
@@ -504,7 +504,7 @@ func (r *GetFilenameFormattingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -581,7 +581,7 @@ type GetStatsRequest struct {
 func NewGetStatsRequest() GetStatsRequest {
 	return GetStatsRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetStats",
 			err:   make(chan error, 1),
 		},
@@ -594,7 +594,7 @@ func (r *GetStatsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -682,7 +682,7 @@ func NewBroadcastCustomMessageRequest(
 		realm,
 		data,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "BroadcastCustomMessage",
 			err:   make(chan error, 1),
 		},
@@ -695,7 +695,7 @@ func (r *BroadcastCustomMessageRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -769,7 +769,7 @@ type GetVideoInfoRequest struct {
 func NewGetVideoInfoRequest() GetVideoInfoRequest {
 	return GetVideoInfoRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetVideoInfo",
 			err:   make(chan error, 1),
 		},
@@ -782,7 +782,7 @@ func (r *GetVideoInfoRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_outputs.go
+++ b/requests_outputs.go
@@ -22,7 +22,7 @@ type ListOutputsRequest struct {
 func NewListOutputsRequest() ListOutputsRequest {
 	return ListOutputsRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ListOutputs",
 			err:   make(chan error, 1),
 		},
@@ -35,7 +35,7 @@ func (r *ListOutputsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func NewGetOutputInfoRequest(outputName string) GetOutputInfoRequest {
 	return GetOutputInfoRequest{
 		outputName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetOutputInfo",
 			err:   make(chan error, 1),
 		},
@@ -129,7 +129,7 @@ func (r *GetOutputInfoRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func NewStartOutputRequest(outputName string) StartOutputRequest {
 	return StartOutputRequest{
 		outputName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StartOutput",
 			err:   make(chan error, 1),
 		},
@@ -223,7 +223,7 @@ func (r *StartOutputRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func NewStopOutputRequest(
 		outputName,
 		force,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StopOutput",
 			err:   make(chan error, 1),
 		},
@@ -321,7 +321,7 @@ func (r *StopOutputRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_profiles.go
+++ b/requests_profiles.go
@@ -26,7 +26,7 @@ func NewSetCurrentProfileRequest(profileName string) SetCurrentProfileRequest {
 	return SetCurrentProfileRequest{
 		profileName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetCurrentProfile",
 			err:   make(chan error, 1),
 		},
@@ -39,7 +39,7 @@ func (r *SetCurrentProfileRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ type GetCurrentProfileRequest struct {
 func NewGetCurrentProfileRequest() GetCurrentProfileRequest {
 	return GetCurrentProfileRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetCurrentProfile",
 			err:   make(chan error, 1),
 		},
@@ -126,7 +126,7 @@ func (r *GetCurrentProfileRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ type ListProfilesRequest struct {
 func NewListProfilesRequest() ListProfilesRequest {
 	return ListProfilesRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ListProfiles",
 			err:   make(chan error, 1),
 		},
@@ -216,7 +216,7 @@ func (r *ListProfilesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_recording.go
+++ b/requests_recording.go
@@ -22,7 +22,7 @@ type StartStopRecordingRequest struct {
 func NewStartStopRecordingRequest() StartStopRecordingRequest {
 	return StartStopRecordingRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StartStopRecording",
 			err:   make(chan error, 1),
 		},
@@ -35,7 +35,7 @@ func (r *StartStopRecordingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ type StartRecordingRequest struct {
 func NewStartRecordingRequest() StartRecordingRequest {
 	return StartRecordingRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StartRecording",
 			err:   make(chan error, 1),
 		},
@@ -123,7 +123,7 @@ func (r *StartRecordingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ type StopRecordingRequest struct {
 func NewStopRecordingRequest() StopRecordingRequest {
 	return StopRecordingRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StopRecording",
 			err:   make(chan error, 1),
 		},
@@ -211,7 +211,7 @@ func (r *StopRecordingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -286,7 +286,7 @@ type PauseRecordingRequest struct {
 func NewPauseRecordingRequest() PauseRecordingRequest {
 	return PauseRecordingRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "PauseRecording",
 			err:   make(chan error, 1),
 		},
@@ -299,7 +299,7 @@ func (r *PauseRecordingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -374,7 +374,7 @@ type ResumeRecordingRequest struct {
 func NewResumeRecordingRequest() ResumeRecordingRequest {
 	return ResumeRecordingRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ResumeRecording",
 			err:   make(chan error, 1),
 		},
@@ -387,7 +387,7 @@ func (r *ResumeRecordingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -469,7 +469,7 @@ func NewSetRecordingFolderRequest(recFolder string) SetRecordingFolderRequest {
 	return SetRecordingFolderRequest{
 		recFolder,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetRecordingFolder",
 			err:   make(chan error, 1),
 		},
@@ -482,7 +482,7 @@ func (r *SetRecordingFolderRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -556,7 +556,7 @@ type GetRecordingFolderRequest struct {
 func NewGetRecordingFolderRequest() GetRecordingFolderRequest {
 	return GetRecordingFolderRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetRecordingFolder",
 			err:   make(chan error, 1),
 		},
@@ -569,7 +569,7 @@ func (r *GetRecordingFolderRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_replay_buffer.go
+++ b/requests_replay_buffer.go
@@ -22,7 +22,7 @@ type StartStopReplayBufferRequest struct {
 func NewStartStopReplayBufferRequest() StartStopReplayBufferRequest {
 	return StartStopReplayBufferRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StartStopReplayBuffer",
 			err:   make(chan error, 1),
 		},
@@ -35,7 +35,7 @@ func (r *StartStopReplayBufferRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ type StartReplayBufferRequest struct {
 func NewStartReplayBufferRequest() StartReplayBufferRequest {
 	return StartReplayBufferRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StartReplayBuffer",
 			err:   make(chan error, 1),
 		},
@@ -126,7 +126,7 @@ func (r *StartReplayBufferRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ type StopReplayBufferRequest struct {
 func NewStopReplayBufferRequest() StopReplayBufferRequest {
 	return StopReplayBufferRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StopReplayBuffer",
 			err:   make(chan error, 1),
 		},
@@ -214,7 +214,7 @@ func (r *StopReplayBufferRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ type SaveReplayBufferRequest struct {
 func NewSaveReplayBufferRequest() SaveReplayBufferRequest {
 	return SaveReplayBufferRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SaveReplayBuffer",
 			err:   make(chan error, 1),
 		},
@@ -304,7 +304,7 @@ func (r *SaveReplayBufferRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_scene_collections.go
+++ b/requests_scene_collections.go
@@ -26,7 +26,7 @@ func NewSetCurrentSceneCollectionRequest(scName string) SetCurrentSceneCollectio
 	return SetCurrentSceneCollectionRequest{
 		scName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetCurrentSceneCollection",
 			err:   make(chan error, 1),
 		},
@@ -39,7 +39,7 @@ func (r *SetCurrentSceneCollectionRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ type GetCurrentSceneCollectionRequest struct {
 func NewGetCurrentSceneCollectionRequest() GetCurrentSceneCollectionRequest {
 	return GetCurrentSceneCollectionRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetCurrentSceneCollection",
 			err:   make(chan error, 1),
 		},
@@ -126,7 +126,7 @@ func (r *GetCurrentSceneCollectionRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ type ListSceneCollectionsRequest struct {
 func NewListSceneCollectionsRequest() ListSceneCollectionsRequest {
 	return ListSceneCollectionsRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ListSceneCollections",
 			err:   make(chan error, 1),
 		},
@@ -216,7 +216,7 @@ func (r *ListSceneCollectionsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_scene_items.go
+++ b/requests_scene_items.go
@@ -35,7 +35,7 @@ func NewGetSceneItemPropertiesRequest(
 		sceneName,
 		item,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSceneItemProperties",
 			err:   make(chan error, 1),
 		},
@@ -48,7 +48,7 @@ func (r *GetSceneItemPropertiesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func NewSetSceneItemPropertiesRequest(
 		boundsX,
 		boundsY,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSceneItemProperties",
 			err:   make(chan error, 1),
 		},
@@ -297,7 +297,7 @@ func (r *SetSceneItemPropertiesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func NewResetSceneItemRequest(
 		sceneName,
 		item,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ResetSceneItem",
 			err:   make(chan error, 1),
 		},
@@ -396,7 +396,7 @@ func (r *ResetSceneItemRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -487,7 +487,7 @@ func NewSetSceneItemRenderRequest(
 		render,
 		sceneName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSceneItemRender",
 			err:   make(chan error, 1),
 		},
@@ -500,7 +500,7 @@ func (r *SetSceneItemRenderRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -596,7 +596,7 @@ func NewSetSceneItemPositionRequest(
 		x,
 		y,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSceneItemPosition",
 			err:   make(chan error, 1),
 		},
@@ -609,7 +609,7 @@ func (r *SetSceneItemPositionRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -710,7 +710,7 @@ func NewSetSceneItemTransformRequest(
 		yScale,
 		rotation,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSceneItemTransform",
 			err:   make(chan error, 1),
 		},
@@ -723,7 +723,7 @@ func (r *SetSceneItemTransformRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -829,7 +829,7 @@ func NewSetSceneItemCropRequest(
 		left,
 		right,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSceneItemCrop",
 			err:   make(chan error, 1),
 		},
@@ -842,7 +842,7 @@ func (r *SetSceneItemCropRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -938,7 +938,7 @@ func NewDeleteSceneItemRequest(
 		itemName,
 		itemID,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "DeleteSceneItem",
 			err:   make(chan error, 1),
 		},
@@ -951,7 +951,7 @@ func (r *DeleteSceneItemRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -1053,7 +1053,7 @@ func NewDuplicateSceneItemRequest(
 		itemName,
 		itemID,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "DuplicateSceneItem",
 			err:   make(chan error, 1),
 		},
@@ -1066,7 +1066,7 @@ func (r *DuplicateSceneItemRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_scenes.go
+++ b/requests_scenes.go
@@ -26,7 +26,7 @@ func NewSetCurrentSceneRequest(sceneName string) SetCurrentSceneRequest {
 	return SetCurrentSceneRequest{
 		sceneName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetCurrentScene",
 			err:   make(chan error, 1),
 		},
@@ -39,7 +39,7 @@ func (r *SetCurrentSceneRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ type GetCurrentSceneRequest struct {
 func NewGetCurrentSceneRequest() GetCurrentSceneRequest {
 	return GetCurrentSceneRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetCurrentScene",
 			err:   make(chan error, 1),
 		},
@@ -126,7 +126,7 @@ func (r *GetCurrentSceneRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ type GetSceneListRequest struct {
 func NewGetSceneListRequest() GetSceneListRequest {
 	return GetSceneListRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSceneList",
 			err:   make(chan error, 1),
 		},
@@ -219,7 +219,7 @@ func (r *GetSceneListRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -323,7 +323,7 @@ func NewReorderSceneItemsRequest(
 		itemsID,
 		itemsName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ReorderSceneItems",
 			err:   make(chan error, 1),
 		},
@@ -336,7 +336,7 @@ func (r *ReorderSceneItemsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_sources.go
+++ b/requests_sources.go
@@ -22,7 +22,7 @@ type GetSourcesListRequest struct {
 func NewGetSourcesListRequest() GetSourcesListRequest {
 	return GetSourcesListRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSourcesList",
 			err:   make(chan error, 1),
 		},
@@ -35,7 +35,7 @@ func (r *GetSourcesListRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ type GetSourceTypesListRequest struct {
 func NewGetSourceTypesListRequest() GetSourceTypesListRequest {
 	return GetSourceTypesListRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSourceTypesList",
 			err:   make(chan error, 1),
 		},
@@ -135,7 +135,7 @@ func (r *GetSourceTypesListRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -253,7 +253,7 @@ func NewGetVolumeRequest(source string) GetVolumeRequest {
 	return GetVolumeRequest{
 		source,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetVolume",
 			err:   make(chan error, 1),
 		},
@@ -266,7 +266,7 @@ func (r *GetVolumeRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,7 @@ func NewSetVolumeRequest(
 		source,
 		volume,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetVolume",
 			err:   make(chan error, 1),
 		},
@@ -375,7 +375,7 @@ func (r *SetVolumeRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -453,7 +453,7 @@ func NewGetMuteRequest(source string) GetMuteRequest {
 	return GetMuteRequest{
 		source,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetMute",
 			err:   make(chan error, 1),
 		},
@@ -466,7 +466,7 @@ func (r *GetMuteRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -557,7 +557,7 @@ func NewSetMuteRequest(
 		source,
 		mute,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetMute",
 			err:   make(chan error, 1),
 		},
@@ -570,7 +570,7 @@ func (r *SetMuteRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -648,7 +648,7 @@ func NewToggleMuteRequest(source string) ToggleMuteRequest {
 	return ToggleMuteRequest{
 		source,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ToggleMute",
 			err:   make(chan error, 1),
 		},
@@ -661,7 +661,7 @@ func (r *ToggleMuteRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -746,7 +746,7 @@ func NewSetSyncOffsetRequest(
 		source,
 		offset,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSyncOffset",
 			err:   make(chan error, 1),
 		},
@@ -759,7 +759,7 @@ func (r *SetSyncOffsetRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -837,7 +837,7 @@ func NewGetSyncOffsetRequest(source string) GetSyncOffsetRequest {
 	return GetSyncOffsetRequest{
 		source,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSyncOffset",
 			err:   make(chan error, 1),
 		},
@@ -850,7 +850,7 @@ func (r *GetSyncOffsetRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -942,7 +942,7 @@ func NewGetSourceSettingsRequest(
 		sourceName,
 		sourceType,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSourceSettings",
 			err:   make(chan error, 1),
 		},
@@ -955,7 +955,7 @@ func (r *GetSourceSettingsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -1055,7 +1055,7 @@ func NewSetSourceSettingsRequest(
 		sourceType,
 		sourceSettings,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSourceSettings",
 			err:   make(chan error, 1),
 		},
@@ -1068,7 +1068,7 @@ func (r *SetSourceSettingsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -1155,7 +1155,7 @@ func NewGetTextGDIPlusPropertiesRequest(source string) GetTextGDIPlusPropertiesR
 	return GetTextGDIPlusPropertiesRequest{
 		source,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetTextGDIPlusProperties",
 			err:   make(chan error, 1),
 		},
@@ -1168,7 +1168,7 @@ func (r *GetTextGDIPlusPropertiesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -1476,7 +1476,7 @@ func NewSetTextGDIPlusPropertiesRequest(
 		vertical,
 		render,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetTextGDIPlusProperties",
 			err:   make(chan error, 1),
 		},
@@ -1489,7 +1489,7 @@ func (r *SetTextGDIPlusPropertiesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -1567,7 +1567,7 @@ func NewGetTextFreetype2PropertiesRequest(source string) GetTextFreetype2Propert
 	return GetTextFreetype2PropertiesRequest{
 		source,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetTextFreetype2Properties",
 			err:   make(chan error, 1),
 		},
@@ -1580,7 +1580,7 @@ func (r *GetTextFreetype2PropertiesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -1787,7 +1787,7 @@ func NewSetTextFreetype2PropertiesRequest(
 		textFile,
 		wordWrap,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetTextFreetype2Properties",
 			err:   make(chan error, 1),
 		},
@@ -1800,7 +1800,7 @@ func (r *SetTextFreetype2PropertiesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -1878,7 +1878,7 @@ func NewGetBrowserSourcePropertiesRequest(source string) GetBrowserSourcePropert
 	return GetBrowserSourcePropertiesRequest{
 		source,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetBrowserSourceProperties",
 			err:   make(chan error, 1),
 		},
@@ -1891,7 +1891,7 @@ func (r *GetBrowserSourcePropertiesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2043,7 +2043,7 @@ func NewSetBrowserSourcePropertiesRequest(
 		shutdown,
 		render,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetBrowserSourceProperties",
 			err:   make(chan error, 1),
 		},
@@ -2056,7 +2056,7 @@ func (r *SetBrowserSourcePropertiesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2130,7 +2130,7 @@ type GetSpecialSourcesRequest struct {
 func NewGetSpecialSourcesRequest() GetSpecialSourcesRequest {
 	return GetSpecialSourcesRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSpecialSources",
 			err:   make(chan error, 1),
 		},
@@ -2143,7 +2143,7 @@ func (r *GetSpecialSourcesRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2236,7 +2236,7 @@ func NewGetSourceFiltersRequest(sourceName string) GetSourceFiltersRequest {
 	return GetSourceFiltersRequest{
 		sourceName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSourceFilters",
 			err:   make(chan error, 1),
 		},
@@ -2249,7 +2249,7 @@ func (r *GetSourceFiltersRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2349,7 +2349,7 @@ func NewGetSourceFilterInfoRequest(
 		sourceName,
 		filterName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetSourceFilterInfo",
 			err:   make(chan error, 1),
 		},
@@ -2362,7 +2362,7 @@ func (r *GetSourceFilterInfoRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2470,7 +2470,7 @@ func NewAddFilterToSourceRequest(
 		filterType,
 		filterSettings,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "AddFilterToSource",
 			err:   make(chan error, 1),
 		},
@@ -2483,7 +2483,7 @@ func (r *AddFilterToSourceRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2568,7 +2568,7 @@ func NewRemoveFilterFromSourceRequest(
 		sourceName,
 		filterName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "RemoveFilterFromSource",
 			err:   make(chan error, 1),
 		},
@@ -2581,7 +2581,7 @@ func (r *RemoveFilterFromSourceRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2671,7 +2671,7 @@ func NewReorderSourceFilterRequest(
 		filterName,
 		newIndex,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ReorderSourceFilter",
 			err:   make(chan error, 1),
 		},
@@ -2684,7 +2684,7 @@ func (r *ReorderSourceFilterRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2775,7 +2775,7 @@ func NewMoveSourceFilterRequest(
 		filterName,
 		movementType,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "MoveSourceFilter",
 			err:   make(chan error, 1),
 		},
@@ -2788,7 +2788,7 @@ func (r *MoveSourceFilterRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2879,7 +2879,7 @@ func NewSetSourceFilterSettingsRequest(
 		filterName,
 		filterSettings,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSourceFilterSettings",
 			err:   make(chan error, 1),
 		},
@@ -2892,7 +2892,7 @@ func (r *SetSourceFilterSettingsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -2982,7 +2982,7 @@ func NewSetSourceFilterVisibilityRequest(
 		filterName,
 		filterEnabled,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetSourceFilterVisibility",
 			err:   make(chan error, 1),
 		},
@@ -2995,7 +2995,7 @@ func (r *SetSourceFilterVisibilityRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -3107,7 +3107,7 @@ func NewTakeSourceScreenshotRequest(
 		width,
 		height,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "TakeSourceScreenshot",
 			err:   make(chan error, 1),
 		},
@@ -3120,7 +3120,7 @@ func (r *TakeSourceScreenshotRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_streaming.go
+++ b/requests_streaming.go
@@ -22,7 +22,7 @@ type GetStreamingStatusRequest struct {
 func NewGetStreamingStatusRequest() GetStreamingStatusRequest {
 	return GetStreamingStatusRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetStreamingStatus",
 			err:   make(chan error, 1),
 		},
@@ -35,7 +35,7 @@ func (r *GetStreamingStatusRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ type StartStopStreamingRequest struct {
 func NewStartStopStreamingRequest() StartStopStreamingRequest {
 	return StartStopStreamingRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StartStopStreaming",
 			err:   make(chan error, 1),
 		},
@@ -138,7 +138,7 @@ func (r *StartStopStreamingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func NewStartStreamingRequest(
 		streamSettingsUsername,
 		streamSettingsPassword,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StartStreaming",
 			err:   make(chan error, 1),
 		},
@@ -278,7 +278,7 @@ func (r *StartStreamingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -353,7 +353,7 @@ type StopStreamingRequest struct {
 func NewStopStreamingRequest() StopStreamingRequest {
 	return StopStreamingRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "StopStreaming",
 			err:   make(chan error, 1),
 		},
@@ -366,7 +366,7 @@ func (r *StopStreamingRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func NewSetStreamSettingsRequest(
 		settingsPassword,
 		save,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetStreamSettings",
 			err:   make(chan error, 1),
 		},
@@ -498,7 +498,7 @@ func (r *SetStreamSettingsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -572,7 +572,7 @@ type GetStreamSettingsRequest struct {
 func NewGetStreamSettingsRequest() GetStreamSettingsRequest {
 	return GetStreamSettingsRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetStreamSettings",
 			err:   make(chan error, 1),
 		},
@@ -585,7 +585,7 @@ func (r *GetStreamSettingsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -683,7 +683,7 @@ type SaveStreamSettingsRequest struct {
 func NewSaveStreamSettingsRequest() SaveStreamSettingsRequest {
 	return SaveStreamSettingsRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SaveStreamSettings",
 			err:   make(chan error, 1),
 		},
@@ -696,7 +696,7 @@ func (r *SaveStreamSettingsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -775,7 +775,7 @@ func NewSendCaptionsRequest(text string) SendCaptionsRequest {
 	return SendCaptionsRequest{
 		text,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SendCaptions",
 			err:   make(chan error, 1),
 		},
@@ -788,7 +788,7 @@ func (r *SendCaptionsRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_studio_mode.go
+++ b/requests_studio_mode.go
@@ -22,7 +22,7 @@ type GetStudioModeStatusRequest struct {
 func NewGetStudioModeStatusRequest() GetStudioModeStatusRequest {
 	return GetStudioModeStatusRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetStudioModeStatus",
 			err:   make(chan error, 1),
 		},
@@ -35,7 +35,7 @@ func (r *GetStudioModeStatusRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ type GetPreviewSceneRequest struct {
 func NewGetPreviewSceneRequest() GetPreviewSceneRequest {
 	return GetPreviewSceneRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetPreviewScene",
 			err:   make(chan error, 1),
 		},
@@ -126,7 +126,7 @@ func (r *GetPreviewSceneRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func NewSetPreviewSceneRequest(sceneName string) SetPreviewSceneRequest {
 	return SetPreviewSceneRequest{
 		sceneName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetPreviewScene",
 			err:   make(chan error, 1),
 		},
@@ -223,7 +223,7 @@ func (r *SetPreviewSceneRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -315,7 +315,7 @@ func NewTransitionToProgramRequest(
 		withTransitionName,
 		withTransitionDuration,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "TransitionToProgram",
 			err:   make(chan error, 1),
 		},
@@ -328,7 +328,7 @@ func (r *TransitionToProgramRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ type EnableStudioModeRequest struct {
 func NewEnableStudioModeRequest() EnableStudioModeRequest {
 	return EnableStudioModeRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "EnableStudioMode",
 			err:   make(chan error, 1),
 		},
@@ -415,7 +415,7 @@ func (r *EnableStudioModeRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -489,7 +489,7 @@ type DisableStudioModeRequest struct {
 func NewDisableStudioModeRequest() DisableStudioModeRequest {
 	return DisableStudioModeRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "DisableStudioMode",
 			err:   make(chan error, 1),
 		},
@@ -502,7 +502,7 @@ func (r *DisableStudioModeRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -576,7 +576,7 @@ type ToggleStudioModeRequest struct {
 func NewToggleStudioModeRequest() ToggleStudioModeRequest {
 	return ToggleStudioModeRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "ToggleStudioMode",
 			err:   make(chan error, 1),
 		},
@@ -589,7 +589,7 @@ func (r *ToggleStudioModeRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}

--- a/requests_transitions.go
+++ b/requests_transitions.go
@@ -22,7 +22,7 @@ type GetTransitionListRequest struct {
 func NewGetTransitionListRequest() GetTransitionListRequest {
 	return GetTransitionListRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetTransitionList",
 			err:   make(chan error, 1),
 		},
@@ -35,7 +35,7 @@ func (r *GetTransitionListRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ type GetCurrentTransitionRequest struct {
 func NewGetCurrentTransitionRequest() GetCurrentTransitionRequest {
 	return GetCurrentTransitionRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetCurrentTransition",
 			err:   make(chan error, 1),
 		},
@@ -131,7 +131,7 @@ func (r *GetCurrentTransitionRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func NewSetCurrentTransitionRequest(transitionName string) SetCurrentTransitionR
 	return SetCurrentTransitionRequest{
 		transitionName,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetCurrentTransition",
 			err:   make(chan error, 1),
 		},
@@ -228,7 +228,7 @@ func (r *SetCurrentTransitionRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func NewSetTransitionDurationRequest(duration int) SetTransitionDurationRequest 
 	return SetTransitionDurationRequest{
 		duration,
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "SetTransitionDuration",
 			err:   make(chan error, 1),
 		},
@@ -319,7 +319,7 @@ func (r *SetTransitionDurationRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}
@@ -393,7 +393,7 @@ type GetTransitionDurationRequest struct {
 func NewGetTransitionDurationRequest() GetTransitionDurationRequest {
 	return GetTransitionDurationRequest{
 		_request{
-			ID_:   getMessageID(),
+			ID_:   GetMessageID(),
 			Type_: "GetTransitionDuration",
 			err:   make(chan error, 1),
 		},
@@ -406,7 +406,7 @@ func (r *GetTransitionDurationRequest) Send(c Client) error {
 	if r.sent {
 		return ErrAlreadySent
 	}
-	future, err := c.sendRequest(r)
+	future, err := c.SendRequest(r)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There are requests that have optional parameters. For example, I want to have `GetSourceSettingsRequest` without `SourceType` being set; since having it set with empty string `""` has different meaning.

One way I can do this kind of variation of requests is to create custom requests and responses of my own. And the only blocking point when creating custom request & response is that
`Client.sendRequest()` and `getMessageID()` are private.